### PR TITLE
Add checkout retrieve API

### DIFF
--- a/lib/affirm.rb
+++ b/lib/affirm.rb
@@ -5,6 +5,7 @@ require 'affirm/client'
 require 'affirm/response'
 require 'affirm/charge_event'
 require 'affirm/charge'
+require 'affirm/checkout'
 
 require 'affirm/errors/error'
 require 'affirm/errors/charge_error'

--- a/lib/affirm/checkout.rb
+++ b/lib/affirm/checkout.rb
@@ -1,0 +1,45 @@
+module Affirm
+  class Checkout
+    attr_reader :id, :merchant, :shipping, :billing, :items, :discounts, :metadata, :order_id,
+      :currency, :financing_program, :shipping_amount, :tax_amount, :total
+
+    ##
+    # RETRIEVE
+    #
+    # id - (required) string. The checkout id
+    def self.retrieve(id, client: Affirm::API.client)
+      new(attrs: {"id" => id}, client: client).refresh
+    end
+
+    def initialize(attrs: {}, client: Affirm::API.client)
+      @client = client
+      set_attrs(attrs)
+    end
+
+    def refresh
+      response = @client.make_request("/checkout/#{id}", :get)
+
+      set_attrs(response.body)
+
+      self
+    end
+
+    private
+
+    def set_attrs(attrs)
+      @id                = attrs["id"]
+      @merchant          = attrs["merchant"]
+      @shipping          = attrs["shipping"]
+      @billing           = attrs["billing"]
+      @items             = attrs["items"]
+      @discounts         = attrs["discounts"]
+      @metadata          = attrs["metadata"]
+      @order_id          = attrs["order_id"]
+      @currency          = attrs["currency"]
+      @financing_program = attrs["financing_program"]
+      @shipping_amount   = attrs["shipping_amount"]
+      @tax_amount        = attrs["tax_amount"]
+      @total             = attrs["total"]
+    end
+  end
+end

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Affirm::Checkout do
+  let(:id) { "ABCD" }
+  let!(:request) do
+    stub_request(request_method, request_url).to_return(status: response_code, body: response_body)
+  end
+
+  let(:response_code) { 200 }
+
+  let(:checkout) { Affirm::Checkout.new(attrs: {"id" => id}) }
+
+  describe "self.retrieve" do
+    let(:request_method) { :get }
+    let(:request_url) { "#{TEST_URL}/checkout/#{id}" }
+    let(:response_body) { load_fixture("checkout/retrieve.json") }
+
+    it "returns a checkout" do
+      checkout = Affirm::Checkout.retrieve(id)
+
+      checkout.should be_a Affirm::Checkout
+    end
+
+    it "sets attributes" do
+      checkout = Affirm::Checkout.retrieve(id)
+
+      checkout.id.should == id
+      checkout.currency.should == "USD"
+      checkout.total.should == 6100
+      checkout.order_id.should == "order_id_123"
+      checkout.financing_program.should == "flyus_3z6r12r"
+      checkout.tax_amount.should == 700
+      checkout.shipping_amount.should == 800
+      checkout.metadata.should == { "mode" => "modal", "invoice_id" => "invoice_id_123"}
+    end
+
+    context "not found" do
+      let(:response_code) { 404 }
+
+      it "raises an error" do
+        expect { Affirm::Checkout.retrieve(id) }.to raise_error(Affirm::ResourceNotFoundError)
+      end
+    end
+  end
+
+  context "with specified client" do
+    let(:client) { Affirm::Client.new(public_key: "other_public", secret_key: "other_secret") }
+
+    let(:request_method) { :get }
+    let(:response_body) { load_fixture("checkout/retrieve.json") }
+    let(:request_url) { /.*other_public:other_secret.*/ }
+
+    it "uses the client's creds" do
+      Affirm::Checkout.retrieve(id, client: client)
+    end
+  end
+end

--- a/spec/fixtures/checkout/retrieve.json
+++ b/spec/fixtures/checkout/retrieve.json
@@ -1,0 +1,37 @@
+{
+  "id":"ABCD",
+  "currency":"USD",
+  "total":6100,
+  "order_id":"order_id_123",
+  "items":{
+    "sweater-a92123":{
+      "sku":"sweater-a92123",
+      "display_name":"Sweater",
+      "qty":1,
+      "item_type":"physical",
+      "item_image_url":"http://placehold.it/350x150",
+      "item_url":"http://placehold.it/350x150",
+      "unit_price":5000
+    }
+  },
+  "shipping_amount":400,
+  "tax_amount":700,
+  "financing_program": "flyus_3z6r12r",
+  "shipping_amount":800,
+  "shipping":{
+    "name":{
+      "full":"John Doe"
+    },
+    "address":{
+      "line1":"325 Pacific Ave",
+      "city":"San Francisco",
+      "state":"CA",
+      "zipcode":"94112",
+      "country":"USA"
+    }
+  },
+  "metadata": {
+    "mode": "modal",
+    "invoice_id": "invoice_id_123"
+  }
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177918697

This PR introduces the missing functionality from the base affirm-ruby gem to allow us to fetch checkouts from Affirm

This commit is tagged `clutter-v1.0.0` for inclusion in our platform gemfile